### PR TITLE
Sprint 4/issue 40#change reading screen

### DIFF
--- a/languageApp/src/components/ToReadCard/ToReadCard.tsx
+++ b/languageApp/src/components/ToReadCard/ToReadCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {View, Text, TouchableOpacity} from 'react-native';
 import styles from './styles';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
@@ -8,6 +8,7 @@ interface ToReadCardProps {
   author?: string;
   moral?: string;
   onPress?: () => void;
+  read?: boolean;
 }
 
 export const ToReadCard: React.FC<ToReadCardProps> = ({
@@ -15,7 +16,14 @@ export const ToReadCard: React.FC<ToReadCardProps> = ({
   author,
   moral,
   onPress,
+  read,
 }) => {
+  const [markRead, setMarkRead] = useState(read);
+
+  const handleMarkRead = () => {
+    read = !markRead;
+    setMarkRead(!markRead);
+  };
   return (
     <TouchableOpacity onPress={onPress}>
       <View style={styles.container}>
@@ -24,12 +32,13 @@ export const ToReadCard: React.FC<ToReadCardProps> = ({
             <Text style={styles.title}>{title}</Text>
             <Text style={styles.author}>{author}</Text>
           </View>
-          <Icon
-            style={styles.icon}
-            name="heart-circle"
-            size={30}
-            color="#04BFAD"
-          />
+          <TouchableOpacity onPress={handleMarkRead}>
+            <Icon
+              name={markRead ? 'eye' : 'eye-outline'}
+              size={40}
+              color="#04BFAD"
+            />
+          </TouchableOpacity>
         </View>
 
         <View style={styles.moralContainer}>

--- a/languageApp/src/components/ToReadCard/ToReadCard.tsx
+++ b/languageApp/src/components/ToReadCard/ToReadCard.tsx
@@ -35,7 +35,7 @@ export const ToReadCard: React.FC<ToReadCardProps> = ({
           <TouchableOpacity onPress={handleMarkRead}>
             <Icon
               name={markRead ? 'eye' : 'eye-outline'}
-              size={40}
+              size={25}
               color="#04BFAD"
             />
           </TouchableOpacity>

--- a/languageApp/src/screens/StoryScreen/StoryScreen.tsx
+++ b/languageApp/src/screens/StoryScreen/StoryScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {View, ScrollView, Text, TouchableOpacity} from 'react-native';
 import styles from './styles';
 //components
@@ -9,15 +9,29 @@ import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 interface StoryProps {
   title?: string;
   author?: string;
+  read?: boolean;
 }
 
-export const StoryScreen: React.FC<StoryProps> = ({title, author}) => {
+export const StoryScreen: React.FC<StoryProps> = ({title, author, read}) => {
+  const [markRead, setMarkRead] = useState(read);
+
+  const handleMarkRead = () => {
+    read = !markRead;
+    setMarkRead(!markRead);
+  };
+
   return (
     <View style={styles.container}>
       <View style={styles.upPartContainer}>
         <ReadingImage />
-        <TouchableOpacity style={styles.favoritesButton}>
-          <Icon name="heart-circle" size={40} color="#04BFAD" />
+        <TouchableOpacity
+          style={styles.favoritesButton}
+          onPress={handleMarkRead}>
+          <Icon
+            name={markRead ? 'eye' : 'eye-outline'}
+            size={40}
+            color="#04BFAD"
+          />
         </TouchableOpacity>
       </View>
       <View style={styles.storyContainer}>


### PR DESCRIPTION
# Description

In this pull request, we are refining the user experience on the "to-read" screen by revisiting the icon selection. Previously, we utilized a heart icon intended for marking stories as favorites. However, we have opted to replace this with an eye icon, which will now serve the purpose of allowing users to designate stories as "read." This strategic adjustment is designed to enhance visual clarity for our users. By implementing this change, we aim to provide a more intuitive means for users to discern between stories they've explored and those that remain unread.


## Screenshots
![markread](https://github.com/BrightCoders-Institute/proyecto-final-rn-teamb/assets/114469877/75582c65-efcd-444c-9257-28b0c8321549)
![mread](https://github.com/BrightCoders-Institute/proyecto-final-rn-teamb/assets/114469877/32f2ee1b-4fa8-4549-99e4-942d57d39a70)

